### PR TITLE
add a client tool to show client info and manage client proxy friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Submit a pull request to add awesome plugins you write or find.
 
 * [lukacu/docker-frps](https://github.com/lukacu/docker-frps) - Persistent port reservations and ACMEProxy to automatically secure exposed HTTP connections and redirect them to HTTPS.
 
-* [frps-multiuser](https://github.com/yhl452493373/frps-multiuser) - A plugin with manage ui to manage user and limit ports, domains, subdomains for each user.
+* [frps-panel](https://github.com/yhl452493373/frps-panel) - A plugin to show server info and support multiple user. You can also manage user with manage ui, and limit ports, domains, subdomains for each user.
 
 ### 中文插件
 
 * [dev-lluo/frps-auth](https://github.com/dev-lluo/frps-auth) - 支持为每个代理设置 token 进行鉴权。
 * [arugal/frp-notify](https://github.com/arugal/frp-notify) - 一个专注于消息通知的服务端管理插件，支持钉钉和 gotify 。
 * [zfb132/frp_info](https://github.com/zfb132/frp_info) - 屏蔽或允许指定IP的用户建立SSH连接。
-* [frps-multiuser](https://github.com/yhl452493373/frps-multiuser) - 带管理界面的多用户管理插件，可以动态管理用户，可以限制用户端口、自定义域名、子域名
+* [frps-panel](https://github.com/yhl452493373/frps-panel) - 一个展示服务器信息，且支持多用户鉴权的插件，同时可以动态管理用户，可以限制用户端口、自定义域名、子域名

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ Submit a pull request to add awesome plugins you write or find.
 
 * [frps-panel](https://github.com/yhl452493373/frps-panel) - A plugin to show server info and support multiple user. You can also manage user with manage ui, and limit ports, domains, subdomains for each user.
 
+* [frpc-panel](https://github.com/yhl452493373/frpc-panel) - A client tool to show client info and add proxy more friendly
+
 ### 中文插件
 
 * [dev-lluo/frps-auth](https://github.com/dev-lluo/frps-auth) - 支持为每个代理设置 token 进行鉴权。
 * [arugal/frp-notify](https://github.com/arugal/frp-notify) - 一个专注于消息通知的服务端管理插件，支持钉钉和 gotify 。
 * [zfb132/frp_info](https://github.com/zfb132/frp_info) - 屏蔽或允许指定IP的用户建立SSH连接。
 * [frps-panel](https://github.com/yhl452493373/frps-panel) - 一个展示服务器信息，且支持多用户鉴权的插件，同时可以动态管理用户，可以限制用户端口、自定义域名、子域名
+* [frpc-panel](https://github.com/yhl452493373/frpc-panel) - 一个更友好的展示、管理客户端代理信息的客户端工具


### PR DESCRIPTION
做了一个客户端工具，用来展示客户端信息、添加客户端代理。比自带的更易用，支持国际化、深色模式。

截图都是1280x720截的，有些字段展示不完整。1920x1080就没这问题。

前端仍然是 jquery + layui + layui-theme-dark 的组合实现的。

<img width="1281" alt="client_info" src="https://github.com/gofrp/plugin/assets/26134687/9b8eaf1c-63b0-4692-bdf6-26c8f2bde41c">
<img width="1282" alt="proxy_overview" src="https://github.com/gofrp/plugin/assets/26134687/d26f453e-2c2e-4822-a721-6b8b78ba2494">
<img width="1280" alt="darkmode" src="https://github.com/gofrp/plugin/assets/26134687/6e0857f4-f3de-41ef-b66f-5b5e1aceb1f1">
<img width="1278" alt="extra_params" src="https://github.com/gofrp/plugin/assets/26134687/36784957-a631-486d-8c39-f7f5452810e4">
<img width="1282" alt="login" src="https://github.com/gofrp/plugin/assets/26134687/6510a908-99ba-4d95-a0a7-1522245fe528">
<img width="1280" alt="new_proxy" src="https://github.com/gofrp/plugin/assets/26134687/273f31da-cd69-4b2b-a097-a7ba20fcb436">
<img width="1281" alt="proxy_list" src="https://github.com/gofrp/plugin/assets/26134687/b8302ff7-7e18-42f7-9e9a-718df576fed7">
<img width="1282" alt="client_info_i18n" src="https://github.com/gofrp/plugin/assets/26134687/d7337ac4-c2f1-4fbc-822d-ea4359f36c49">
